### PR TITLE
fix: correct link for `nixos`

### DIFF
--- a/src/constants/icons.ts
+++ b/src/constants/icons.ts
@@ -4061,7 +4061,7 @@ const icons = [
       "nixos",
       "nixos-horizontal"
     ],
-    "url": "nixos.com"
+    "url": "nixos.org"
   },
   {
     "name": "Nodejs",


### PR DESCRIPTION
[nixos.com](https://nixos.com) -> [nixos.org](https://nixos.org)

fixes #70 