### PR TITLE
fix: correct link for `sass`

### DIFF
--- a/src/constants/icons.ts
+++ b/src/constants/icons.ts
@@ -5160,7 +5160,7 @@ const icons = [
       "sass",
       "sass-wordmark"
     ],
-    "url": "sass.com"
+    "url": "sass-lang.com"
   },
   {
     "name": "Scala",


### PR DESCRIPTION
[sass.com](https://sass.com) -> [sass-lang.com](https://sass-lang.com) 

similar to #71 